### PR TITLE
Fix evaluation of `SOURCE_ROOT` path

### DIFF
--- a/lib/xcodeproj/project/object/helpers/groupable_helper.rb
+++ b/lib/xcodeproj/project/object/helpers/groupable_helper.rb
@@ -153,7 +153,7 @@ module Xcodeproj
                 real_path(object_parent)
               end
             when 'SOURCE_ROOT'
-              object.project.project_dir
+              object.project.project_dir + object.project.root_object.project_dir_path
             when '<absolute>'
               nil
             else

--- a/spec/project/object/helpers/groupable_helper_spec.rb
+++ b/spec/project/object/helpers/groupable_helper_spec.rb
@@ -183,8 +183,15 @@ module ProjectSpecs
         @helper.source_tree_real_path(@group).should == Pathname.new('/project_dir')
       end
 
-      it 'check project_dir_path adjustment' do
+      it 'check project_dir_path adjustment relative to main group' do
         @group.source_tree = '<group>'
+        @project.root_object.stubs(:project_dir_path).returns('../')
+        @helper.source_tree_real_path(@group).to_s.should.not.include Pathname.new('/project_dir').to_s
+        Pathname.new('/project_dir').to_s.should.include @helper.source_tree_real_path(@group).to_s
+      end
+
+      it 'check project_dir_path adjustment relative to project root' do
+        @group.source_tree = 'SOURCE_ROOT'
         @project.root_object.stubs(:project_dir_path).returns('../')
         @helper.source_tree_real_path(@group).to_s.should.not.include Pathname.new('/project_dir').to_s
         Pathname.new('/project_dir').to_s.should.include @helper.source_tree_real_path(@group).to_s


### PR DESCRIPTION
The value of the `SOURCE_ROOT` variable was evaluated incorrectly by CocoaPods.

In Xcode, it is the path to the root of the repository (e.g. `~/Developer/shapr3d`) but in the CocoaPods implementation, it was expanded to the path to the project, which, in the case of `KernelProject.xcodeproj` was `~/Developer/shapr3d/build/cmake`.

This mismatch caused CocoaPods to not find the `.xcconfig` file of targets generated by CMake (e.g. `SPLibBinginsTests`).

> [!TIP]
> See https://github.com/CocoaPods/CocoaPods/issues/6268 for more info. Specifically [this](https://github.com/CocoaPods/CocoaPods/issues/6268#issuecomment-443689964) comment.

> [!NOTE]
> Opened a PR for upstream: https://github.com/CocoaPods/Xcodeproj/pull/1024